### PR TITLE
Fix package dependency (remove importing "r2q")

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,9 +34,7 @@ Imports:
     sf,
     stringr,
     tidyr,
-    readr,
-    r2q
-  
+    readr
 Suggests: 
     covr,
     flexdashboard,


### PR DESCRIPTION
functions written in the same package must not be imported in the DESCRIPTION file